### PR TITLE
Add a docker image for the server

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,24 @@
+FROM rust:1.98-slim AS builder
+
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+RUN cargo build --release --bin VRCStreamer
+
+FROM gcr.io/distroless/cc-debian13 AS runtime
+WORKDIR /app
+COPY --from=builder /app/target/release/VRCStreamer .
+COPY placeholders ./placeholders
+
+EXPOSE 80 443 554
+
+ENV SERVER_NAME="Self-Hosted Instance"
+ENV BIND_ADDR="0.0.0.0:80"
+ENV TLS_CERT_PATH=none
+ENV TLS_KEY_PATH=none
+ENV RTSP_BIND_ADDR="0.0.0.0:554"
+ENV RUST_LOG="warn"
+
+CMD ["./VRCStreamer"]


### PR DESCRIPTION
This PR is a pretty simple Dockerfile that builds and runs the VRCStreamer server. 

The runtime is [Distroless](https://github.com/GoogleContainerTools/distroless) for minimizing security vulnerabilities, and just defines a few defaults based on the .env.example, mainly meant for the server running behind a reverse proxy like Traefik or Caddy, which seem common in dockerized setups and would handle SSL themselves. (however, SSL like the standalone executable should work roughly the same if mounted to the container)

I haven't added instructions for running the docker version in the README or included a github action to automatically push an image to ghcr, but if you'd like me to add either before merging i'm more than willing c:

Thanks for making this project!!